### PR TITLE
Remove order From JSON Schema

### DIFF
--- a/primary/src/routes/manage/orgconfig.ts
+++ b/primary/src/routes/manage/orgconfig.ts
@@ -183,13 +183,15 @@ router.post('/submitform', wrap(async (req, res) => {
 	logger.debug('form_type=' + form_type);
 
 	let formdata: Layout[] = JSON.parse(jsonString);
-	formdata.forEach( (element) => {
+	formdata.forEach((element, i) => {
 		// just in case the submission has '_id' attributes, remove them
 		delete element['_id'];
 		// write (or override existing) attributes
 		element.form_type = form_type;
 		element.org_key = org_key;
 		element.year = year;
+		// add order key to each object
+		element.order = i;
 	});
 	let updatedString = JSON.stringify(formdata);
 	logger.debug('updatedString=' + updatedString);

--- a/primary/src/routes/manage/orgconfig.ts
+++ b/primary/src/routes/manage/orgconfig.ts
@@ -103,19 +103,19 @@ router.get('/editform', wrap(async (req, res) => {
 	else throw new e.UserError('Either "year" or "key" must be set.');
 	
 	// load form definition data from the database
-	let layoutarray: Layout[] = await utilities.find('layout', {org_key: org_key, year: year, form_type: form_type}, {sort: {'order': 1}});
-	// strip out _id, form_type, org_key, year
-	let updatedarray: LayoutEdit[] = [];
-	layoutarray.forEach( (element) => {
-		let newelement: LayoutEdit = element;
-		delete newelement['_id'];
-		delete newelement['form_type'];
-		delete newelement['org_key'];
-		delete newelement['year'];
-		updatedarray.push(newelement);
+	let layoutArray: Layout[] = await utilities.find('layout', {org_key: org_key, year: year, form_type: form_type}, {sort: {'order': 1}});
+	// strip out _id, form_type, org_key, year, order
+	let updatedArray = layoutArray.map((element) => {
+		let newElement: LayoutEdit = element;
+		delete newElement['_id'];
+		delete newElement['form_type'];
+		delete newElement['org_key'];
+		delete newElement['year'];
+		delete newElement['order'];
+		return newElement;
 	});
 	// create a string representation
-	let layout = JSON.stringify(updatedarray, null, 2);
+	let layout = JSON.stringify(updatedArray, null, 2);
 	//logger.debug(thisFuncName + 'layout=\n' + layout);
 
 	let existingFormData = new Map<string, string>();

--- a/primary/views/manage/config/editform.pug
+++ b/primary/views/manage/config/editform.pug
@@ -44,8 +44,6 @@ block content
 			}
 
 			// make sure 'order' and 'id' are unique; also clear out extraneous stuff
-			let orderDict = {};
-			let orderCount = 0
 			let idDict = {};
 			let idCount = 0;
 			for (var i = 0; i < jsonData.length; i++) {
@@ -55,21 +53,13 @@ block content
 				delete jsonData[i]['org_key'];
 				delete jsonData[i]['year'];
 
-				let thisOrder = jsonData[i]['order'];
-				if (thisOrder == null) { 
-					console.log('Missing order:', jsonData[i]);
-					NotificationCard.error("Missing at least one 'order' attribute! Please correct.");
-					return null;
-				}
-				orderCount++;
-				orderDict[thisOrder] = thisOrder;
-
 				let thisType = jsonData[i]['type'];
 				if (thisType == null) { 
 					console.log('Missing type:', jsonData[i]);
 					NotificationCard.error("Missing at least one 'type' attribute! Please correct.");
 					return null;
 				}
+
 				if (thisType != 'spacer') {
 					let thisId = jsonData[i]['id'];
 					if (thisId == null) { 
@@ -84,12 +74,7 @@ block content
 					idDict[thisId] = thisId;
 				}
 			}
-			if (Object.keys(orderDict).length != orderCount)  { 
-				console.log('Keys:', Object.keys(orderDict));
-				console.log(`Count: ${orderCount}`);
-				NotificationCard.error("At least one duplicate 'order' value! Please correct.");
-				return null;
-			}
+
 			if (Object.keys(idDict).length != idCount)  { 
 				console.log('Keys:', Object.keys(idDict));
 				console.log(`Count: ${idCount}`);

--- a/primary/views/manage/config/editform.pug
+++ b/primary/views/manage/config/editform.pug
@@ -47,11 +47,12 @@ block content
 			let idDict = {};
 			let idCount = 0;
 			for (var i = 0; i < jsonData.length; i++) {
-				// while we're iterating through, clear out extraneous stuff if needed
+				// since jsonData gets loaded back to the user, remove backend keys
 				delete jsonData[i]['_id'];
 				delete jsonData[i]['form_type'];
 				delete jsonData[i]['org_key'];
 				delete jsonData[i]['year'];
+				delete jsonData[i]['order'];
 
 				let thisType = jsonData[i]['type'];
 				if (thisType == null) { 

--- a/scoutradioz-types/types.d.ts
+++ b/scoutradioz-types/types.d.ts
@@ -104,10 +104,11 @@ export declare interface Layout extends DbDocument {
  * @collection layoutedit
  * @interface LayoutEdit
  */
-export declare interface LayoutEdit extends Omit<Layout, 'form_type' | 'org_key' | 'year'> {
+export declare interface LayoutEdit extends Omit<Layout, 'form_type' | 'org_key' | 'year' | 'order'> {
 	year?: number;
 	form_type?: 'matchscouting'|'pitscouting';
 	org_key?: OrgKey;
+	order?: number|string;
 }
 
 /**


### PR DESCRIPTION
Resolves #122 by removing the need for users to define the "order" key value pair in their JSON. Instead, the order is automatically injecting into the JSON data received from the website before the post request to the database is generated. Front end validation code is also updated to no longer check for this property.

I don't have everything building on my local machine yet, so I wasn't able to actually run this code, so please actually test before pushing to live.