### PR TITLE
Add Min and Max to Seniority and Years on Team

### DIFF
--- a/primary/views/manage/members/index.pug
+++ b/primary/views/manage/members/index.pug
@@ -82,7 +82,15 @@ block content
 											option(value=role.role_key)= role.label
 							//years
 							div(class="w3-col s6 m1 w3-padding-small")
-								input(type="number" value=member.org_info.years name="years" placeholder="Yrs. on team" class="w3-input theme-input w3-no-border theme-inline-padding")
+								input(
+										type="number"
+										value=member.org_info.years
+										name="years"
+										min=0
+										max=150
+										placeholder="Yrs. on team"
+										class="w3-input theme-input w3-no-border theme-inline-padding"
+									)
 			br 
 		hr
 		//new member
@@ -113,7 +121,14 @@ block content
 							option(value=role.role_key)= role.label
 				//years
 				div(class="w3-col s6 m1 w3-padding-small")
-					input(class="w3-input theme-input w3-no-border theme-inline-padding" name="years" type="number" placeholder="Yrs. on team")
+					input(
+						name="years" 
+						type="number" 
+						placeholder="Yrs. on team"
+						min=0
+						max=150
+						class="w3-input theme-input w3-no-border theme-inline-padding" 
+						)
 		h6
 			i If you create a Team Admin user, please make sure they log in and create a secure password for themselves. Otherwise, a student could log in as them.
 			i 

--- a/primary/views/mixins/orgConfig.pug
+++ b/primary/views/mixins/orgConfig.pug
@@ -24,7 +24,14 @@ mixin classname(index, classname)
 			div(class="w3-col s3 w3-padding-small")
 				input(type="text" class="theme-input" name=`classes_${index}_classkey` value=classname.class_key)
 			div(class="w3-col s3 w3-padding-small")
-				input(type="number" class="theme-input" name=`classes_${index}_seniority` value=classname.seniority)
+				input(
+					type="number"
+					class="theme-input"
+					name=`classes_${index}_seniority`
+					min=0
+					max=1000
+					value=classname.seniority
+					)
 			div(class="w3-col s3 w3-padding-small")
 				select(class="theme-input" name=`classes_${index}_youth`)
 					if classname.youth == true


### PR DESCRIPTION
This is pretty minor, but it's currently possible to enter negative values for the years you've been on the team as well as the seniority. This PR adds (somewhat arbitrary) limits of 0 to 150 for years on team, and 0 to 1000 for seniority.