### PR TITLE
Alliance select, 1-off match scout, pit assign

### DIFF
--- a/primary/src/routes/manage/assignments.ts
+++ b/primary/src/routes/manage/assignments.ts
@@ -7,6 +7,7 @@ import Permissions from '../../helpers/permissions';
 import e, { assert, lightAssert } from 'scoutradioz-http-errors';
 import type { Match, MatchFormData, MatchScouting, OrgSubteam, PitScouting, PitScoutingSet, ScouterRecord, ScoutingPair, Team, TeamKey, User, UserAgent, WithDbId} from 'scoutradioz-types';
 import { AnyBulkWriteOperation, ObjectId } from 'mongodb';
+import { isFunctionOrConstructorTypeNode } from 'typescript';
 
 const router = express.Router();
 const logger = getLogger('assignments');
@@ -31,6 +32,16 @@ router.get('/', wrap(async (req, res) => {
 	const org_key = thisUser.org_key;
 	const event_key = req.event.key;
 	
+	// 2023-03-29, M.O'C: Checking list of teams
+	//Get list of currentteams
+	let teamsArray = req.teams;
+	logger.debug(`teamsArray.length = ${teamsArray?.length}`);
+	let areTeamsListedInDB = true;
+	if (!teamsArray || teamsArray.length < 1) {
+		areTeamsListedInDB = false;
+		logger.warn(`Pit scouting but no teams found in DB`);
+	}
+
 	//Log message so we can see on the server side when we enter this
 	logger.info('ENTER org_key=' + org_key);
 	logger.debug('Requesting all members from db');
@@ -106,7 +117,8 @@ router.get('/', wrap(async (req, res) => {
 				assigned: assigned,
 				available: available,
 				matchScoutingCount: matchScoutingCount,
-				pitScoutingCount: pitScoutingCount
+				pitScoutingCount: pitScoutingCount,
+				areTeamsListedInDB: areTeamsListedInDB
 			});
 		});
 }));

--- a/primary/src/routes/manage/assignments.ts
+++ b/primary/src/routes/manage/assignments.ts
@@ -7,7 +7,6 @@ import Permissions from '../../helpers/permissions';
 import e, { assert, lightAssert } from 'scoutradioz-http-errors';
 import type { Match, MatchFormData, MatchScouting, OrgSubteam, PitScouting, PitScoutingSet, ScouterRecord, ScoutingPair, Team, TeamKey, User, UserAgent, WithDbId} from 'scoutradioz-types';
 import { AnyBulkWriteOperation, ObjectId } from 'mongodb';
-import { isFunctionOrConstructorTypeNode } from 'typescript';
 
 const router = express.Router();
 const logger = getLogger('assignments');

--- a/primary/views/dashboard/allianceselection.pug
+++ b/primary/views/dashboard/allianceselection.pug
@@ -42,7 +42,8 @@ block content
 		p.i!=msg('allianceselection.intro')
 		p.i!=msgMarked('allianceselection.preferred')
 		if !matchcountConsistent
-			button(onclick="document.location.href='/manage/currentevent/matches'" class="w3-btn theme-red") <b>WARNING: Rankings appear NOT to be up to date!</b><br/>Update FIRST data before using for selection
+			a(href="/manage/currentevent/matches") 
+				div(class="w3-btn theme-red") <b>WARNING: Rankings appear NOT to be up to date!</b><br/>Update FIRST data before using for selection
 		div(class="w3-row w3-padding-small")
 			div(class="w3-left")
 				div(id="undo" class="w3-btn theme-submit")!=msg('allianceselection.undo')

--- a/primary/views/dashboard/allianceselection.pug
+++ b/primary/views/dashboard/allianceselection.pug
@@ -41,6 +41,8 @@ block content
 	div(class="w3-mobile w3-center")
 		p.i!=msg('allianceselection.intro')
 		p.i!=msgMarked('allianceselection.preferred')
+		if !matchcountConsistent
+			button(onclick="document.location.href='/manage/currentevent/matches'" class="w3-btn theme-red") <b>WARNING: Rankings appear NOT to be up to date!</b><br/>Update FIRST data before using for selection
 		div(class="w3-row w3-padding-small")
 			div(class="w3-left")
 				div(id="undo" class="w3-btn theme-submit")!=msg('allianceselection.undo')

--- a/primary/views/dashboard/matches.pug
+++ b/primary/views/dashboard/matches.pug
@@ -11,7 +11,8 @@ block content
 	else
 		h3(class="theme-text w3-margin-bottom")!=msg('scouting.match')
 		if !futureMatchResultsConsistent
-			button(onclick="document.location.href='/manage/currentevent/matches'" class="w3-btn theme-red") <b>WARNING: A match result may have been missed!</b><br/>Please check FIRST matches data and update missing matches.
+			a(href="/manage/currentevent/matches") 
+				div(class="w3-btn theme-red") <b>WARNING: A match result may have been missed!</b><br/>Please check FIRST matches data and update missing matches.
 		div(class="w3-col w3-container")
 			- var col = 0
 			while col < 3

--- a/primary/views/dashboard/matches.pug
+++ b/primary/views/dashboard/matches.pug
@@ -10,6 +10,8 @@ block content
 		+noDataFound("There are no match scouting assignments in the system now", "Please check back later")
 	else
 		h3(class="theme-text w3-margin-bottom")!=msg('scouting.match')
+		if !futureMatchResultsConsistent
+			button(onclick="document.location.href='/manage/currentevent/matches'" class="w3-btn theme-red") <b>WARNING: A match result may have been missed!</b><br/>Please check FIRST matches data and update missing matches.
 		div(class="w3-col w3-container")
 			- var col = 0
 			while col < 3

--- a/primary/views/manage/assignments/index.pug
+++ b/primary/views/manage/assignments/index.pug
@@ -6,6 +6,8 @@
 extends ../../layout
 block content
 	h2=title
+	if !areTeamsListedInDB
+		button(onclick="document.location.href='/manage'" class="w3-btn theme-red") <b>WARNING: No teams found in DB!</b><br/>Please update list of teams (or) edit team list.
 	table(class="w3-table")
 		each subteam in subteams
 			th(class="w3-center" style=`width: ${99.999 * 1/subteams.length}%;`)=subteam.label

--- a/primary/views/manage/assignments/index.pug
+++ b/primary/views/manage/assignments/index.pug
@@ -7,7 +7,8 @@ extends ../../layout
 block content
 	h2=title
 	if !areTeamsListedInDB
-		button(onclick="document.location.href='/manage'" class="w3-btn theme-red") <b>WARNING: No teams found in DB!</b><br/>Please update list of teams (or) edit team list.
+		a(href="/manage") 
+			div(class="w3-btn theme-red") <b>WARNING: No teams found in DB!</b><br/>Please update list of teams (or) edit team list.
 	table(class="w3-table")
 		each subteam in subteams
 			th(class="w3-center" style=`width: ${99.999 * 1/subteams.length}%;`)=subteam.label


### PR DESCRIPTION
Adding sanity checks & links to common fixes for...

- **Alliance selection:** If the rankings aren't finalized, point to updating FIRST match data
- **One-off match scouting:** If there is a gap in match results, point to updating FIRST match data
- **Pit scouting assignments:** If there are no teams in the DB for this comp, point to Manage (to either update from API or manually enter) 