### PR TITLE
Fix FIRST matches page: semis have correct numbers

### DIFF
--- a/primary/views/manage/currentevent/matches.pug
+++ b/primary/views/manage/currentevent/matches.pug
@@ -34,7 +34,10 @@ block content
 			each match in matches
 				tr
 					td= match.comp_level
-					td= match.match_number
+					if match.comp_level == 'sf'
+						td= match.set_number
+					else
+						td= match.match_number
 					td= zoneTime(1000 * match.time).toLocaleString(DateTime.DATETIME_SHORT)
 					if match.actual_time
 						td= zoneTime(1000 * match.actual_time).toLocaleString(DateTime.DATETIME_SHORT)


### PR DESCRIPTION
Semifinals are no longer best of three; instead each semifinal match has a 'set number'. Updated /manage/currentevent/matches so for "sf" comp_level, the page shows 'set_number' rather than 'match_number'.